### PR TITLE
Add disableTls option to tool

### DIFF
--- a/cmd/go-imap-sync/go-imap-sync.go
+++ b/cmd/go-imap-sync/go-imap-sync.go
@@ -27,10 +27,12 @@ func getPassword(username, server string) (password string) {
 
 func main() {
 	var server, username, mailbox, emailDir string
+	var disableTls bool
 	flag.StringVar(&server, "server", "", "sync from this mail server and port (e.g. mail.example.com:993)")
 	flag.StringVar(&username, "username", "", "username for logging into the mail server")
 	flag.StringVar(&mailbox, "mailbox", "", "mailbox to read messages from (typically INBOX or INBOX/subfolder)")
 	flag.StringVar(&emailDir, "messagesDir", "messages", "local directory to save messages in")
+	flag.BoolVar(&disableTls, "disableTls", false, "optionally disable TLS for IMAP")
 	flag.Parse()
 
 	if server == "" {
@@ -41,7 +43,7 @@ func main() {
 
 	password := getPassword(username, server)
 
-	_, err := imapsync.Sync(server, username, password, mailbox, emailDir)
+	_, err := imapsync.Sync(server, username, password, mailbox, emailDir, disableTls)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/go-imap-sync/go-imap-sync.go
+++ b/cmd/go-imap-sync/go-imap-sync.go
@@ -27,12 +27,12 @@ func getPassword(username, server string) (password string) {
 
 func main() {
 	var server, username, mailbox, emailDir string
-	var disableTls bool
+	var disableTLS bool
 	flag.StringVar(&server, "server", "", "sync from this mail server and port (e.g. mail.example.com:993)")
 	flag.StringVar(&username, "username", "", "username for logging into the mail server")
 	flag.StringVar(&mailbox, "mailbox", "", "mailbox to read messages from (typically INBOX or INBOX/subfolder)")
 	flag.StringVar(&emailDir, "messagesDir", "messages", "local directory to save messages in")
-	flag.BoolVar(&disableTls, "disableTls", false, "optionally disable TLS for IMAP")
+	flag.BoolVar(&disableTLS, "disableTls", false, "optionally disable TLS for IMAP")
 	flag.Parse()
 
 	if server == "" {
@@ -43,7 +43,7 @@ func main() {
 
 	password := getPassword(username, server)
 
-	_, err := imapsync.Sync(server, username, password, mailbox, emailDir, disableTls)
+	_, err := imapsync.Sync(server, username, password, mailbox, emailDir, disableTLS)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/sync.go
+++ b/sync.go
@@ -26,13 +26,13 @@ type Result struct {
 }
 
 // Sync downloads and saves all not-yet downloaded emails from the mailbox to the emailDir
-func Sync(server, user, password, mailbox, emailDir string) (*Result, error) {
+func Sync(server, user, password, mailbox, emailDir string, tls bool) (*Result, error) {
 	err := os.MkdirAll(emailDir, 0700)
 	if err != nil {
 		return nil, fmt.Errorf("Error creating email directory %v: %v", emailDir, err)
 	}
 
-	connection, err := connect(server, user, password)
+	connection, err := connect(server, user, password, tls)
 	if err != nil {
 		return nil, fmt.Errorf("Error connecting to %v: %v", server, err)
 	}
@@ -85,9 +85,15 @@ func Sync(server, user, password, mailbox, emailDir string) (*Result, error) {
 }
 
 // connect performs an interactive connection to the given IMAP server
-func connect(server, username, password string) (*client.Client, error) {
+func connect(server, username, password string, tls bool) (*client.Client, error) {
 	log.Printf("Connecting to %v...", server)
-	c, err := client.DialTLS(server, nil)
+	var c *client.Client
+	var err error
+	if tls {
+		c, err = client.DialTLS(server, nil)
+	} else {
+		c, err = client.Dial(server)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When using davmail (for example), it's not necessary to set up TLS for local connections. This option (which is disabled by default to ensure compatibility with current configurations) simply disables TLS for connections when `-disableTls` is passed as an option.